### PR TITLE
TheLowAPIを使うMODとの競合を改善

### DIFF
--- a/src/main/java/com/aki/thelowmod/event/Events.java
+++ b/src/main/java/com/aki/thelowmod/event/Events.java
@@ -112,7 +112,7 @@ public class Events {
 
 
 
-    @SubscribeEvent
+    @SubscribeEvent(receiveCanceled = true)
     public void chatReceived(ClientChatReceivedEvent e){
         if(e.message.getUnformattedText().startsWith("$api")){
             if(e.message.getUnformattedText().split("api ").length != 2){


### PR DESCRIPTION
TheLowAPIを使うMODがほかにあると、Eventがキャンセルされてしまい、TheLowAPIを受け取れなくなる問題を解決しました。